### PR TITLE
Repurpose Tyr host

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -85,7 +85,7 @@
             ];
           };
           tyr = inputs.nixpkgs.lib.nixosSystem {
-            system = "aarch64-linux";
+            system = "x86_64-linux";
             modules = [
               {
                 nixpkgs.overlays = [ self.overlays.default ];

--- a/hosts/tyr/configuration.nix
+++ b/hosts/tyr/configuration.nix
@@ -30,38 +30,10 @@
   # Run unpatched dynamic binaries on NixOS
   programs.nix-ld.enable = true;
 
-  my.awesome = {
-    enable = true;
-    rclua = pkgs.fetchurl {
-      url = "https://gist.githubusercontent.com/rszamszur/054dd09d279890e502322ac3e560ab0f/raw/403d63ae125e316305f2358ea3df469b982cb498/rc.lua";
-      sha256 = "1d1fsm9pd615izwiwv8mz4kxabdyq0ad5pj5k5mx5gq28fg9y73k";
-    };
-  };
-  my.laptop.enable = true;
-  my.bash = {
-    enable = true;
-    gitEmail = builtins.getEnv "TYR_GIT_EMAIL";
-    homepkgs = [
-      pkgs.google-cloud-sdk
-      pkgs.firefox
-      pkgs.keepassxc
-      pkgs.kubectl
-      pkgs.kubernetes-helm
-      pkgs.kubectx
-      pkgs.burpsuite
-      pkgs.mitmproxy
-      pkgs.httpie
-      pkgs.b3
-    ];
-  };
+  my.cache.enable = true;
+  my.bash.enable = true;
   my.vim.enable = true;
   my.podman.enable = true;
-  my.vscode.enable = true;
-  my.chrome.enable = true;
-  my.aarch = {
-    enable = true;
-  };
-  my.remarkable.enable = true;
 
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions

--- a/hosts/tyr/hardware-configuration.nix
+++ b/hosts/tyr/hardware-configuration.nix
@@ -9,20 +9,20 @@
       (modulesPath + "/profiles/qemu-guest.nix")
     ];
 
-  boot.initrd.availableKernelModules = [ "xhci_pci" "virtio_pci" "usbhid" "usb_storage" "sr_mod" ];
+  boot.initrd.availableKernelModules = [ "ata_piix" "uhci_hcd" "virtio_pci" "virtio_scsi" "sd_mod" "sr_mod" ];
   boot.initrd.kernelModules = [ ];
   boot.kernelModules = [ ];
   boot.extraModulePackages = [ ];
 
   fileSystems."/" =
     {
-      device = "/dev/disk/by-uuid/dcde33bf-298e-4fc4-9149-174f69b93b37";
-      fsType = "btrfs";
+      device = "/dev/disk/by-uuid/55d08b3b-e014-498b-b73f-c78f0fa15484";
+      fsType = "ext4";
     };
 
   fileSystems."/boot" =
     {
-      device = "/dev/disk/by-uuid/1B3E-B009";
+      device = "/dev/disk/by-uuid/12CE-A600";
       fsType = "vfat";
     };
 
@@ -33,7 +33,7 @@
   # still possible to use this option, but it's recommended to use it in conjunction
   # with explicit per-interface declarations with `networking.interfaces.<interface>.useDHCP`.
   networking.useDHCP = lib.mkDefault true;
-  # networking.interfaces.enp0s1.useDHCP = lib.mkDefault true;
+  # networking.interfaces.ens18.useDHCP = lib.mkDefault true;
 
-  nixpkgs.hostPlatform = lib.mkDefault "aarch64-linux";
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
 }

--- a/hosts/tyr/install.sh
+++ b/hosts/tyr/install.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash
+#! nix-shell -p git
+#! nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixos-23.11.tar.gz
+
+if [ -n "$DEBUG" ]; then
+    set -x
+fi
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# EFI system partition on a GUID Partition Table is identified by the partition type GUID C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+sfdisk /dev/sda << EOF
+label: gpt
+,500M,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+;
+EOF
+
+mkfs.vfat -n boot /dev/sda1
+mkfs.ext4 -L root /dev/sda2
+mount /dev/sda2 /mnt
+mkdir /mnt/boot
+mount /dev/sda1 /mnt/boot
+
+nixos-generate-config --root /mnt
+
+mkdir /mnt/var
+pushd /mnt/var
+git clone https://github.com/rszamszur/nixos-config.git
+popd
+
+pushd /mnt/etc/nixos
+mv configuration.nix configuration.generated.nix
+ln -s ../../var/nixos-config/hosts/tyr/configuration.nix configuration.nix
+mv hardware-configuration.nix /mnt/var/nixos-config/hosts/tyr
+ln -s ../../var/nixos-config/hosts/tyr/hardware-configuration.nix hardware-configuration.nix
+popd
+
+nixos-install --no-root-password --flake /mnt/var/nixos-config#tyr


### PR DESCRIPTION
Repurpose Tyr host to NixOS builder VM -> prerequisite for rszamszur/home-ops#63
White at it, add a very basic script for provisioning Tyr NixOS host (partially resolves issue: #34)