### PR TITLE
fix(sound): adds missing alsa-utils package

### DIFF
--- a/modules/sound.nix
+++ b/modules/sound.nix
@@ -52,9 +52,18 @@ in
     services.blueman.enable = true;
     programs.noisetorch.enable = true;
 
-    environment.systemPackages = [
-      pkgs.pavucontrol
-    ];
+    environment.systemPackages =
+      [
+        pkgs.alsa-utils
+      ]
+      ++ lib.optionals (cfg.driver == "pulseaudio")
+        [
+          pkgs.pavucontrol
+        ]
+      ++ lib.optionals (cfg.driver == "pipewire")
+        [
+          pkgs.pwvucontrol
+        ];
 
     security.rtkit.enable = true;
   };


### PR DESCRIPTION
Since 24.11 `volume-control` widget for awesome-wm stopped working. It seems `asla-utils` package was missing.