### PR TITLE
fix(forgejo-runners): set required label type

### DIFF
--- a/hosts/tyr/configuration.nix
+++ b/hosts/tyr/configuration.nix
@@ -117,8 +117,8 @@ in
         url = "https://git.szamszur.cloud";
         tokenFile = config.sops.secrets.forgejo-runners-token.path;
         labels = [
-          "nixos"
-          config.networking.hostName
+          "nixos:host"
+          "${config.networking.hostName}:host"
         ];
         hostPackages = [
           pkgs.git


### PR DESCRIPTION
https://forgejo.org/docs/latest/admin/actions/configuration/#choosing-labels

> The label type determines what containerization system will be used to run the workflow. There are three options:
> 
> 1. docker for [Docker or Podman](https://forgejo.org/docs/latest/admin/actions/configuration/#docker-or-podman) containerization,
> 2. lxc for [LXC](https://forgejo.org/docs/latest/admin/actions/configuration/#lxc) containerization,
> 3. host for [no containerization](https://forgejo.org/docs/latest/admin/actions/configuration/#host).